### PR TITLE
Use RFC 4566 as reference for direction attributes

### DIFF
--- a/draft-holmberg-mmusic-t140-usage-data-channel.xml
+++ b/draft-holmberg-mmusic-t140-usage-data-channel.xml
@@ -179,18 +179,12 @@
           <t>
             'dcsa' attributes can contain the SDP 'sendonly', 'recvonly', 'sendrecv' and
             'inactive' attributes <xref target="RFC4566"/> to negotite the direction in 
-            which text can be transmitted in a real-time text conversation, following
-            the procedures in <xref target="RFC3264"/>.
+            which text can be transmitted in a real-time text conversation.
           </t>
           <t>
             NOTE: A WebRTC data channel is always bi-directional. The usage of the 'dcsa'
             attribute only affects the direction in which implementations are allowed to
             transmit text on a T.140 data channel.
-          </t>
-          <t>
-            The offer/answer rules for the direction attributes are based on the rules 
-            for unicast streams defined in <xref target="RFC3264"/>, as described below. 
-            Note that the rules only apply to the direction attributes.
           </t>
           <t>
             NOTE: As for any other attribute included in a 'dcsa' attribute, the direction 


### PR DESCRIPTION
In 3.2.3Delete references to RFC 3264 for direction attributes. The info here and in RFC 4566 (and even better in RFC 4566 bis) is sufficient. RFC 3264 has too much of RTP details for this case.