### PR TITLE
Session level direction attributes should work

### DIFF
--- a/draft-holmberg-mmusic-t140-usage-data-channel.xml
+++ b/draft-holmberg-mmusic-t140-usage-data-channel.xml
@@ -198,9 +198,9 @@
             is used. They have no impact on other data channels.
           </t>
           <t>
-            Session level direction attributes <xref target="RFC4566"/> have no impact
-            on a T.140 data channel. An offerer and answerer MUST mark the direction of
-            the text by sending a direction attribute inside ‘dcsa- attribute.
+            Session level direction attributes <xref target="RFC4566"/> have impact
+            on a T.140 data channel only when no direction attribute has been declared 
+            as a direction attribute inside a ‘dcsa- attribute for the T.140 data channel.
           </t>
           <section anchor="sec.sdp.dcsa.dir.neg" title="Negotiate Text Direction">
             <section anchor="sec.sdp.dcsa.dir.neg.off" title="Generating an Offer">


### PR DESCRIPTION
Session level direction attributes should work on T.140 data channels where no direction attribute is set on the dcsa(t140) level. 
RFC 4566bis seems to expect that.
It should be discussed what happens if there is a direction attribute on media level in the media declaration for the SCTP declaration..  Probably a similar statement as for session level is needed.