### PR TITLE
Acting on loss is specified twice for gateway data channels

### DIFF
--- a/draft-holmberg-mmusic-t140-usage-data-channel.xml
+++ b/draft-holmberg-mmusic-t140-usage-data-channel.xml
@@ -475,10 +475,6 @@ Answer:
             text marker <xref target="T140ad1"/> in the data sent on the outgoing T.140 data channel. 
           </t>
           <t>
-            If the gateway detects or suspects loss of data on the T.140 data channel, the gateway gateway SHOULD insert the T.140 missing
-            text marker <xref target="T140ad1"/> in the data sent on the outgoing RTP stream. 
-          </t>
-          <t>
             If the gateway detects that the T.140 data channel has failed and got torn down, once the data channel has been reestablished
             the gateway SHOULD insert the T.140 missing text marker <xref target="T140ad1"/> in the data sent on the outgoing RTP stream
             if it detects or suspects that data on the T.140 data channel was lost.


### PR DESCRIPTION
Delete the improper specification on how to act on loss in data channels for gateways.