### PR TITLE
It should be allowed to specify 'ordered= true' in 'dcmap' which is t…

### DIFF
--- a/draft-holmberg-mmusic-t140-usage-data-channel.xml
+++ b/draft-holmberg-mmusic-t140-usage-data-channel.xml
@@ -124,8 +124,12 @@
           applies to data channels negotiated using the mechanism defined in this document.
         </t>
         <t>
-          The offerer and answerer MUST NOT include the max-retr, max-time and ordered
+          The offerer and answerer MUST NOT include the max-retr and max-time
           attribute parameters in the 'dcmap' attribute.
+        </t>
+        <t>
+          If the ordered attribute parameter is included in the 'dcmap' attribute, it MUST
+          have the value 'true'.
         </t>
         <t>
           Below is an example of the 'dcmap' attribute for a T.140


### PR DESCRIPTION
…he same as omittting it