### PR TITLE
'ordered' with value 'true' should be allowed

### DIFF
--- a/draft-ietf-mmusic-t140-usage-data-channel.xml
+++ b/draft-ietf-mmusic-t140-usage-data-channel.xml
@@ -124,8 +124,12 @@
           applies to data channels negotiated using the mechanism defined in this document.
         </t>
         <t>
-          The offerer and answerer MUST NOT include the max-retr, max-time and ordered
+          The offerer and answerer MUST NOT include the max-retr and max-time
           attribute parameters in the 'dcmap' attribute.
+        </t>
+        <t>
+          If the ordered attribute parameter is included in the 'dcmap' attribute, it MUST
+          be assigned the value 'true'.
         </t>
         <t>
           Below is an example of the 'dcmap' attribute for a T.140


### PR DESCRIPTION
The general syntax from sdpneg is that ordered is allowed. So, allow it here too, but require it to have value 'true', that is also the default.