### PR TITLE
Use plain single quotes around 'dcsa'.

### DIFF
--- a/draft-ietf-mmusic-t140-usage-data-channel.xml
+++ b/draft-ietf-mmusic-t140-usage-data-channel.xml
@@ -200,7 +200,7 @@
           <t>
             Session level direction attributes <xref target="RFC4566"/> have no impact
             on a T.140 data channel. An offerer and answerer MUST mark the direction of
-            the text by sending a direction attribute inside ‘dcsa- attribute.
+            the text by sending a direction attribute inside 'dcsa' attribute.
           </t>
           <section anchor="sec.sdp.dcsa.dir.neg" title="Negotiate Text Direction">
             <section anchor="sec.sdp.dcsa.dir.neg.off" title="Generating an Offer">


### PR DESCRIPTION
One case of dcsa has other characters than ' as quotes.