### PR TITLE
use term "stream id" instead of "stream"  for the parameter.

### DIFF
--- a/draft-ietf-mmusic-t140-usage-data-channel.xml
+++ b/draft-ietf-mmusic-t140-usage-data-channel.xml
@@ -133,7 +133,7 @@
         </t>
         <t>
           Below is an example of the 'dcmap' attribute for a T.140
-          data channel with stream=3 and without any label:
+          data channel with stream id=3 and without any label:
         </t>
         <t>
           a=dcmap:3 subprotocol="t140"


### PR DESCRIPTION
The stream parameter is called "stream id"  or "stream identifier" in sdpneg. I suggest to align with that use.